### PR TITLE
 Add scripts to build production zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,8 @@ typings/
 # Private key files
 *.pem
 
+# Compiled typescript files
 dist/
+
+# Build artifacts for deployment
+artifacts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:12 as install
+WORKDIR /build
+COPY tsconfig.json .
+COPY package.json .
+RUN yarn install
+COPY src/ src/
+
+FROM install as build
+RUN yarn build
+
+FROM install as test
+COPY test/ test/
+COPY jest.config.js .
+RUN yarn test
+
+FROM node:12 as prod-build
+WORKDIR /out
+COPY package.json .
+RUN yarn install --production
+
+FROM alpine:3 as zip
+RUN apk -U --no-cache add zip
+WORKDIR /build
+COPY --from=build /build/dist dist/
+COPY --from=prod-build /out/node_modules node_modules/
+RUN zip -FSr /pytorch-probot.zip .
+
+FROM scratch as prod
+COPY --from=zip /pytorch-probot.zip .

--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ side-by-side.
 ## Deploying to AWS
 
 ```sh
-yarn --production
-zip -FSr ../pytorch-probot.zip . -x '*.git*' '*.env*'
-s3cmd put ../pytorch-probot.zip s3://ossci-assets/pytorch-probot.zip
+scripts/build-prod
+s3cmd put artifacts/pytorch-probot.zip s3://ossci-assets/pytorch-probot.zip
 ```
 
 Then "Upload a file from Amazon S3" from the web UI at https://console.aws.amazon.com/lambda/home?region=us-east-1#/functions/pytorch-probot?tab=graph (using the above s3 url)

--- a/scripts/build-prod
+++ b/scripts/build-prod
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if ! docker buildx version >/dev/null 2>/dev/null; then
+    echo "ERROR: You need docker buildx on your system to use this script"
+    echo "       Refer to https://github.com/docker/buildx#installing"
+    exit 1
+fi
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+(
+    set -x
+    docker buildx build --target prod -o artifacts/ "${ROOT_DIR}"
+)

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,5 +1,5 @@
 // Require the adapter
-import {adapt} from 'probot-actions-adapter';
+import adapt from 'probot-actions-adapter';
 
 // Require your Probot app's entrypoint, usually this is just index.js
 import probot from './index';


### PR DESCRIPTION
New instructions should be in the `README.md`

# Usage:

```
scripts/build-prod
```

# Notes:

Requires docker with [buildx](https://github.com/docker/buildx)
