### PR TITLE
src: Allow params to be set to false on label

### DIFF
--- a/src/trigger-circleci-workflows.ts
+++ b/src/trigger-circleci-workflows.ts
@@ -92,6 +92,14 @@ export function genCircleParametersForPR(
     // ci/all is a special label that will set all to true
     if (appliedLabels.includes('ci/all') || appliedLabels.includes(label)) {
       parameters[labelsToParams[label].parameter] = true;
+      if (labelsToParams[label]['set_to_false']) {
+        const falseParams = labelsToParams[label]['set_to_false'];
+        // There's potential for labels to override each other which we should
+        // probably be careful of
+        for (const falseLabel of Object.keys(falseParams)) {
+          parameters[falseParams[falseLabel]] = false;
+        }
+      }
     }
   }
   return parameters;
@@ -121,6 +129,14 @@ function genCircleParametersForPush(
       context.log.debug({pattern}, 'genParametersForPush');
       if (strippedRef.match(pattern)) {
         parameters[labelsToParams[label].parameter] = true;
+        if (labelsToParams[label]['set_to_false']) {
+          const falseParams = labelsToParams[label]['set_to_false'];
+          // There's potential for labels to override each other which we should
+          // probably be careful of
+          for (const falseLabel of Object.keys(falseParams)) {
+            parameters[falseParams[falseLabel]] = false;
+          }
+        }
       }
     }
   }

--- a/test/trigger-circleci-workflows.test.ts
+++ b/test/trigger-circleci-workflows.test.ts
@@ -16,6 +16,8 @@ labels_to_circle_params:
         - ci-all/.*
       tags:
         - v[0-9]+(\.[0-9]+)*-rc[0-9]+
+    set_to_false:
+      - default
   ci/bleh:
     parameter: run_bleh_tests
   ci/foo:
@@ -61,7 +63,8 @@ describe('trigger-circleci-workflows', () => {
             branch: 'test_branch',
             parameters: {
               run_binaries_tests: true,
-              run_bleh_tests: true
+              run_bleh_tests: true,
+              default: false
             }
           });
           return true;
@@ -88,7 +91,8 @@ describe('trigger-circleci-workflows', () => {
             parameters: {
               run_binaries_tests: true,
               run_bleh_tests: true,
-              run_foo_tests: true
+              run_foo_tests: true,
+              default: false
             }
           });
           return true;
@@ -118,7 +122,8 @@ describe('trigger-circleci-workflows', () => {
             branch: 'pull/1/head',
             parameters: {
               run_binaries_tests: true,
-              run_bleh_tests: true
+              run_bleh_tests: true,
+              default: false
             }
           });
           return true;
@@ -146,7 +151,8 @@ describe('trigger-circleci-workflows', () => {
             parameters: {
               run_binaries_tests: true,
               run_bleh_tests: true,
-              run_foo_tests: true
+              run_foo_tests: true,
+              default: false
             }
           });
           return true;
@@ -169,7 +175,8 @@ describe('trigger-circleci-workflows', () => {
           expect(body).toStrictEqual({
             branch: 'nightly',
             parameters: {
-              run_binaries_tests: true
+              run_binaries_tests: true,
+              default: false
             }
           });
           return true;
@@ -192,7 +199,8 @@ describe('trigger-circleci-workflows', () => {
           expect(body).toStrictEqual({
             branch: 'ci-all/bleh',
             parameters: {
-              run_binaries_tests: true
+              run_binaries_tests: true,
+              default: false
             }
           });
           return true;
@@ -215,7 +223,8 @@ describe('trigger-circleci-workflows', () => {
           expect(body).toStrictEqual({
             tag: 'v1.5.0-rc1',
             parameters: {
-              run_binaries_tests: true
+              run_binaries_tests: true,
+              default: false
             }
           });
           return true;


### PR DESCRIPTION
Adds functionality to set some CircleCI parameters to false when
applying labels. Should make it so that workflows don't have the
potential to get run twice.

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>