### PR TITLE
Enable a ci/no-build label

### DIFF
--- a/src/trigger-circleci-workflows.ts
+++ b/src/trigger-circleci-workflows.ts
@@ -27,7 +27,7 @@ async function loadConfig(context: probot.Context): Promise<Config | {}> {
   let configObj = repoMap.get(repoKey);
   if (configObj === undefined) {
     context.log.debug(`Grabbing config for ${repoKey}`, 'loadConfig');
-    configObj = await context.config(configName) as Config | {};
+    configObj = (await context.config(configName)) as Config | {};
     if (configObj === null || !configObj['labels_to_circle_params']) {
       return {};
     }
@@ -37,7 +37,10 @@ async function loadConfig(context: probot.Context): Promise<Config | {}> {
   return repoMap.get(repoKey);
 }
 
-function isValidConfig(context: probot.Context, config: Config | {}): config is Config {
+function isValidConfig(
+  context: probot.Context,
+  config: Config | {}
+): config is Config {
   if (Object.keys(config).length === 0 || !config['labels_to_circle_params']) {
     context.log.debug(
       `No valid configuration found for repository ${utils.repoKey(context)}`

--- a/src/trigger-circleci-workflows.ts
+++ b/src/trigger-circleci-workflows.ts
@@ -2,17 +2,32 @@ import axios from 'axios';
 import * as probot from 'probot';
 import * as utils from './utils';
 
+interface LabelParams {
+  parameter: string;
+  default_true_on?: {
+    branches?: string[];
+    tags?: string[];
+  };
+  set_to_false?: boolean;
+}
+
+interface Config {
+  labels_to_circle_params: {
+    [label: string]: LabelParams;
+  };
+}
+
 export const configName = 'pytorch-circleci-labels.yml';
 export const circleAPIUrl = 'https://circleci.com';
 const circleToken = process.env.CIRCLE_TOKEN;
-const repoMap = new Map<string, object>();
+const repoMap = new Map<string, Config | {}>();
 
-async function loadConfig(context: probot.Context): Promise<object> {
+async function loadConfig(context: probot.Context): Promise<Config | {}> {
   const repoKey = utils.repoKey(context);
   let configObj = repoMap.get(repoKey);
   if (configObj === undefined) {
     context.log.debug(`Grabbing config for ${repoKey}`, 'loadConfig');
-    configObj = await context.config(configName);
+    configObj = await context.config(configName) as Config | {};
     if (configObj === null || !configObj['labels_to_circle_params']) {
       return {};
     }
@@ -22,7 +37,7 @@ async function loadConfig(context: probot.Context): Promise<object> {
   return repoMap.get(repoKey);
 }
 
-function isValidConfig(context: probot.Context, config: object): boolean {
+function isValidConfig(context: probot.Context, config: Config | {}): config is Config {
   if (Object.keys(config).length === 0 || !config['labels_to_circle_params']) {
     context.log.debug(
       `No valid configuration found for repository ${utils.repoKey(context)}`
@@ -81,19 +96,19 @@ export function circlePipelineEndpoint(repoKey: string): string {
 }
 
 export function genCircleParametersForPR(
-  config: object,
+  config: Config,
   context: probot.Context,
   appliedLabels: string[]
 ): object {
   context.log.debug({config, appliedLabels}, 'genParametersForPR');
   const parameters = {};
-  const labelsToParams = config['labels_to_circle_params'];
+  const labelsToParams = config.labels_to_circle_params;
   for (const label of Object.keys(labelsToParams)) {
     // ci/all is a special label that will set all to true
     if (appliedLabels.includes('ci/all') || appliedLabels.includes(label)) {
       parameters[labelsToParams[label].parameter] = true;
-      if (labelsToParams[label]['set_to_false']) {
-        const falseParams = labelsToParams[label]['set_to_false'];
+      if (labelsToParams[label].set_to_false) {
+        const falseParams = labelsToParams[label].set_to_false;
         // There's potential for labels to override each other which we should
         // probably be careful of
         for (const falseLabel of Object.keys(falseParams)) {
@@ -106,31 +121,31 @@ export function genCircleParametersForPR(
 }
 
 function genCircleParametersForPush(
-  config: object,
+  config: Config,
   context: probot.Context
 ): object {
   const parameters = {};
-  const labelsToParams = config['labels_to_circle_params'];
+  const labelsToParams = config.labels_to_circle_params;
   const onTag: boolean = context.payload['ref'].startsWith('refs/tags');
   const strippedRef: string = stripReference(context.payload['ref']);
   for (const label of Object.keys(labelsToParams)) {
     context.log.debug({label}, 'genParametersForPush');
-    if (!labelsToParams[label]['default_true_on']) {
+    if (!labelsToParams[label].default_true_on) {
       context.log.debug(
         `No default_true_on found for ${label}`,
         'genParametersForPush'
       );
       continue;
     }
-    const defaultTrueOn = labelsToParams[label]['default_true_on'];
+    const defaultTrueOn = labelsToParams[label].default_true_on;
     const refsToMatch = onTag ? 'tags' : 'branches';
     context.log.debug({defaultTrueOn, refsToMatch, strippedRef});
     for (const pattern of defaultTrueOn[refsToMatch]) {
       context.log.debug({pattern}, 'genParametersForPush');
       if (strippedRef.match(pattern)) {
         parameters[labelsToParams[label].parameter] = true;
-        if (labelsToParams[label]['set_to_false']) {
-          const falseParams = labelsToParams[label]['set_to_false'];
+        if (labelsToParams[label].set_to_false) {
+          const falseParams = labelsToParams[label].set_to_false;
           // There's potential for labels to override each other which we should
           // probably be careful of
           for (const falseLabel of Object.keys(falseParams)) {

--- a/test/trigger-circleci-workflows.test.ts
+++ b/test/trigger-circleci-workflows.test.ts
@@ -7,9 +7,18 @@ import * as triggerCircleBot from '../src/trigger-circleci-workflows';
 nock.disableNetConnect();
 
 const EXAMPLE_CONFIG = `
+default_params:
+  default: true
 labels_to_circle_params:
   ci/binaries:
     parameter: run_binaries_tests
+    default_true_on:
+      branches:
+        - nightly
+        - ci-all/.*
+      tags:
+        - v[0-9]+(\.[0-9]+)*-rc[0-9]+
+  ci/no-default:
     default_true_on:
       branches:
         - nightly
@@ -64,7 +73,7 @@ describe('trigger-circleci-workflows', () => {
             parameters: {
               run_binaries_tests: true,
               run_bleh_tests: true,
-              default: false
+              default: true
             }
           });
           return true;
@@ -112,6 +121,7 @@ describe('trigger-circleci-workflows', () => {
     payload['pull_request']['head']['ref'] = 'test_branch';
     payload['pull_request']['labels'] = [
       {name: 'ci/binaries'},
+      {name: 'ci/no-default'},
       {name: 'ci/bleh'}
     ];
     const scope = nock(`${triggerCircleBot.circleAPIUrl}`)


### PR DESCRIPTION
Enables https://github.com/pytorch/pytorch/pull/58778 by adding the follow two features to the syntax of `.github/pytorch-circleci-labels.yml`:
- a `default_params` section that applies even when no labels are present
- the `parameter` field is now optional on labels