### PR TITLE
Ignore ghstack branches on push

### DIFF
--- a/src/trigger-circleci-workflows.ts
+++ b/src/trigger-circleci-workflows.ts
@@ -207,6 +207,11 @@ async function runBotForPR(context: probot.Context): Promise<void> {
 async function runBotForPush(context: probot.Context): Promise<void> {
   try {
     context.log.info('Recieved push!');
+    const ref = stripReference(context.payload['ref']);
+    if (ref.startsWith('gh/')) {
+      context.log.info('Ignoring ghstack branch');
+      return;
+    }
     const config = await loadConfig(context);
     if (!isValidConfig(context, config)) {
       return;
@@ -217,7 +222,7 @@ async function runBotForPush(context: probot.Context): Promise<void> {
     context.log.info({parameters}, 'runBot');
     if (Object.keys(parameters).length !== 0) {
       await triggerCircleCI(context, {
-        [refKey]: stripReference(context.payload['ref']),
+        [refKey]: ref,
         parameters
       });
     }


### PR DESCRIPTION
This is a temporary fix since https://github.com/pytorch/pytorch/pull/58778 is now causing `gh/**/base` branches to trigger CI when they shouldn't be. The plan is to quickly follow this up with a better system that would exclude those automatically rather than having to special-case it.