### PR TITLE
Allow no-* via pull_request in default_true_on

### DIFF
--- a/test/trigger-circleci-workflows.test.ts
+++ b/test/trigger-circleci-workflows.test.ts
@@ -8,8 +8,6 @@ import * as triggerCircleBot from '../src/trigger-circleci-workflows';
 nock.disableNetConnect();
 
 const EXAMPLE_CONFIG = `
-default_params:
-  default: true
 labels_to_circle_params:
   ci/binaries:
     parameter: run_binaries_tests
@@ -19,15 +17,12 @@ labels_to_circle_params:
         - ci-all/.*
       tags:
         - v[0-9]+(\.[0-9]+)*-rc[0-9]+
-  ci/no-default:
+  ci/default:
+    parameter: default
     default_true_on:
       branches:
-        - nightly
-        - ci-all/.*
-      tags:
-        - v[0-9]+(\.[0-9]+)*-rc[0-9]+
-    set_to_false:
-      - default
+        - master
+      pull_request:
   ci/bleh:
     parameter: run_bleh_tests
   ci/foo:
@@ -125,7 +120,7 @@ describe('trigger-circleci-workflows', () => {
             run_binaries_tests: true,
             run_bleh_tests: true,
             run_foo_tests: true,
-            default: false
+            default: true
           }
         });
         return true;
@@ -156,8 +151,7 @@ describe('trigger-circleci-workflows', () => {
           branch: 'pull/1/head',
           parameters: {
             run_binaries_tests: true,
-            run_bleh_tests: true,
-            default: false
+            run_bleh_tests: true
           }
         });
         return true;
@@ -186,7 +180,7 @@ describe('trigger-circleci-workflows', () => {
             run_binaries_tests: true,
             run_bleh_tests: true,
             run_foo_tests: true,
-            default: false
+            default: true
           }
         });
         return true;
@@ -206,8 +200,7 @@ describe('trigger-circleci-workflows', () => {
         expect(body).toStrictEqual({
           branch: 'nightly',
           parameters: {
-            run_binaries_tests: true,
-            default: false
+            run_binaries_tests: true
           }
         });
         return true;
@@ -227,8 +220,7 @@ describe('trigger-circleci-workflows', () => {
         expect(body).toStrictEqual({
           branch: 'ci-all/bleh',
           parameters: {
-            run_binaries_tests: true,
-            default: false
+            run_binaries_tests: true
           }
         });
         return true;
@@ -248,8 +240,7 @@ describe('trigger-circleci-workflows', () => {
         expect(body).toStrictEqual({
           tag: 'v1.5.0-rc1',
           parameters: {
-            run_binaries_tests: true,
-            default: false
+            run_binaries_tests: true
           }
         });
         return true;


### PR DESCRIPTION
This PR is a replacement for the temporary fix in #25, using a different approach from #22 to enable a `ci/no-build` label: allow the `default_true_on` section to contain a `pull_request` key, and allow _any_ label to be overridden by replacing the leading `ci/` with `ci/no-`. This has a couple benefits:

- As shown in the updated unit tests, instead of explicitly setting `default` to `false`, it is now simply omitted, which removes the need for the `gh/**/base` special case.
- The `default_true_on` `branches` and `tags` now no longer need to be duplicated between `ci/binaries` and `ci/no-build`.