### PR TITLE
Add stub bot to give CI customization info on PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ CC people when labels are added to an issue.
 * If an issue is labeled **topic: flaky-tests**, also label it
   **high priority** and **triage review**
 
+## custom-ci-info-bot
+
+Anytime a PR with `ci/future` is edited, edit its body to contain info about how
+to customize CI on that PR (see the following section). Currently just
+overwrites the entire PR body with a dummy string, so use with caution.
+
 ## trigger-circleci-workflows
 
 * Trigger circleci workflows based off of labeling events / push events

--- a/src/custom-ci-info-bot.ts
+++ b/src/custom-ci-info-bot.ts
@@ -1,5 +1,7 @@
 import * as probot from 'probot';
 
+export const futureLabel = 'ci/future';
+
 // https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab
 const dummy = `
 <details>
@@ -14,13 +16,13 @@ interface Label {
   name: string;
 }
 
-export default function myBot(app: probot.Application): void {
+export function myBot(app: probot.Application): void {
   app.on('pull_request.edited', async context => {
     const {owner, repo} = context.repo();
     const {number, labels, body} = context.payload.pull_request;
     context.log.info({owner, repo, number, body}, 'custom CI info start');
-    if (!labels.map((label: Label) => label.name).includes('ci/future')) {
-      context.log.info('ignoring PR because it has no ci/future label');
+    if (!labels.map((label: Label) => label.name).includes(futureLabel)) {
+      context.log.info({futureLabel}, 'ignoring PR, missing CI future label');
       return;
     }
     // eslint-disable-next-line @typescript-eslint/camelcase

--- a/src/custom-ci-info-bot.ts
+++ b/src/custom-ci-info-bot.ts
@@ -1,0 +1,25 @@
+import * as probot from 'probot';
+
+// https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab
+const dummy = `
+<details>
+<summary>Click to expand...</summary>
+
+_Hello,_ **world!**
+</details>
+`.trim();
+
+export default function myBot(app: probot.Application): void {
+  app.on('pull_request.edited', async context => {
+    const {owner, repo} = context.repo();
+    const {number, labels, body} = context.payload.pull_request;
+    context.log.info({owner, repo, number, body}, 'custom CI info start');
+    if (!labels.map(label => label.name).includes('ci/future')) {
+      context.log.info('ignoring PR because it has no ci/future label');
+      return;
+    }
+    const update = {owner, repo, pull_number: number, body: dummy};
+    context.log.info(update, 'updating PR body');
+    await context.github.pulls.update(update);
+  });
+}

--- a/src/custom-ci-info-bot.ts
+++ b/src/custom-ci-info-bot.ts
@@ -9,15 +9,21 @@ _Hello,_ **world!**
 </details>
 `.trim();
 
+// this has other fields too but we don't use them
+interface Label {
+  name: string;
+}
+
 export default function myBot(app: probot.Application): void {
   app.on('pull_request.edited', async context => {
     const {owner, repo} = context.repo();
     const {number, labels, body} = context.payload.pull_request;
     context.log.info({owner, repo, number, body}, 'custom CI info start');
-    if (!labels.map(label => label.name).includes('ci/future')) {
+    if (!labels.map((label: Label) => label.name).includes('ci/future')) {
       context.log.info('ignoring PR because it has no ci/future label');
       return;
     }
+    // eslint-disable-next-line @typescript-eslint/camelcase
     const update = {owner, repo, pull_number: number, body: dummy};
     context.log.info(update, 'updating PR body');
     await context.github.pulls.update(update);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import autoCcBot from './auto-cc-bot';
 import autoLabelBot from './auto-label-bot';
-import customCiInfoBot from './custom-ci-info-bot';
+import {myBot as customCiInfoBot} from './custom-ci-info-bot';
 import triggerCircleCiBot from './trigger-circleci-workflows';
 import {Application} from 'probot';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import autoCcBot from './auto-cc-bot';
 import autoLabelBot from './auto-label-bot';
+import customCiInfoBot from './custom-ci-info-bot';
 import triggerCircleCiBot from './trigger-circleci-workflows';
 import {Application} from 'probot';
 
 function runBot(app: Application): void {
   autoCcBot(app);
   autoLabelBot(app);
+  customCiInfoBot(app);
   triggerCircleCiBot(app);
 }
 

--- a/test/custom-ci-info-bot.test.ts
+++ b/test/custom-ci-info-bot.test.ts
@@ -1,0 +1,42 @@
+import {promises as fs} from 'fs';
+import nock from 'nock';
+import * as utils from './utils';
+import myProbotApp from '../src/custom-ci-info-bot';
+
+nock.disableNetConnect();
+
+async function fixture(): Promise<any> {
+  const payload = JSON.parse(
+    await fs.readFile('test/fixtures/pull_request.labeled.json', 'utf8')
+  );
+  payload.action = 'edited';
+  const futureLabel = 'ci/future';
+  const label = payload.pull_request.labels[2];
+  label.name = futureLabel;
+  label.url = label.url.replace(/ci\/bleh/g, futureLabel);
+  return payload;
+}
+
+describe('custom-ci-info-bot', () => {
+  let probot;
+
+  beforeEach(() => {
+    probot = utils.testProbot();
+    probot.load(myProbotApp);
+    utils.mockAccessToken();
+  });
+
+  test('replace body when pull request is edited', async () => {
+    const payload = await fixture();
+    const scope = nock('https://api.github.com')
+      .patch('/repos/seemethere/test-repo/pulls/20', (body: any) => {
+        expect(body).toMatchObject({
+          body: expect.stringContaining('details')
+        });
+        return true;
+      })
+      .reply(200);
+    await probot.receive({name: 'pull_request', payload, id: '2'});
+    scope.done();
+  });
+});

--- a/test/custom-ci-info-bot.test.ts
+++ b/test/custom-ci-info-bot.test.ts
@@ -31,7 +31,7 @@ describe('custom-ci-info-bot', () => {
     const scope = nock('https://api.github.com')
       .patch('/repos/seemethere/test-repo/pulls/20', (body: any) => {
         expect(body).toMatchObject({
-          body: expect.stringContaining('details')
+          body: expect.stringContaining('<details>')
         });
         return true;
       })

--- a/test/custom-ci-info-bot.test.ts
+++ b/test/custom-ci-info-bot.test.ts
@@ -1,7 +1,7 @@
 import {promises as fs} from 'fs';
 import nock from 'nock';
 import * as utils from './utils';
-import myProbotApp from '../src/custom-ci-info-bot';
+import {futureLabel, myBot as myProbotApp} from '../src/custom-ci-info-bot';
 
 nock.disableNetConnect();
 
@@ -10,7 +10,6 @@ async function fixture(): Promise<any> {
     await fs.readFile('test/fixtures/pull_request.labeled.json', 'utf8')
   );
   payload.action = 'edited';
-  const futureLabel = 'ci/future';
   const label = payload.pull_request.labels[2];
   label.name = futureLabel;
   label.url = label.url.replace(/ci\/bleh/g, futureLabel);


### PR DESCRIPTION
Starting to work on addressing https://github.com/pytorch/pytorch/issues/59818; see the `README.md` diff for a description of what this currently does. I'm asking for review on this PR to validate the general idea and make sure everyone's OK with deploying this on just `ci/future` for now (I'll use https://github.com/pytorch/pytorch/pull/60101 as a testbed), but after this is merged, I'll probably be able to mostly iterate locally via unit tests.

@seemethere Do you know if/how I could add a second `test` to assert that `nock('https://api.github.com').patch('/repos/seemethere/test-repo/pulls/20')` receives no requests if `ci/future` is missing? I tried looking through the [nock documentation](https://github.com/nock/nock) but didn't find anything.