### PR TITLE
Add traceback translation for typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   },
   "dependencies": {
     "@probot/serverless-lambda": "^0.4.0",
+    "@types/source-map-support": "^0.5.4",
     "axios": "^0.21.1",
     "probot": "^9",
-    "probot-actions-adapter": "^1.0.2"
+    "probot-actions-adapter": "^1.0.2",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
+import {install} from 'source-map-support';
+
 import autoCcBot from './auto-cc-bot';
 import autoLabelBot from './auto-label-bot';
 import triggerCircleCiBot from './trigger-circleci-workflows';
 import {Application} from 'probot';
+
+// Needed for traceback translation from transpiled javascript -> typescript
+install();
 
 function runBot(app: Application): void {
   autoCcBot(app);

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,6 +746,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.37.tgz#cb4782d847f801fa58316da5b4801ca3a59ae790"
   integrity sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg==
 
+"@types/source-map-support@^0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@types/source-map-support/-/source-map-support-0.5.4.tgz#574ff6a8636bc0ebae78a8014136f749b3177d58"
+  integrity sha512-9zGujX1sOPg32XLyfgEB/0G9ZnrjthL/Iv1ZfuAjj8LEilHZEpQSQs1scpRXPhHzGYgWiLz9ldF1cI8JhL+yMw==
+  dependencies:
+    source-map "^0.6.0"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -6907,6 +6914,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@^0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.6:
   version "0.5.13"


### PR DESCRIPTION
Exceptions were hard to read through the transpiled javascript so this
adds the source-map-support module which should allow for tracebacks to
be translated back to their equivalent typescript lines.

See https://www.npmjs.com/package/source-map-support

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>