### PR TITLE
Extend cc-bot to PR labelling

### DIFF
--- a/src/auto-cc-bot.ts
+++ b/src/auto-cc-bot.ts
@@ -55,10 +55,13 @@ function myBot(app: probot.Application): void {
     }
   });
 
-  async function runBotForLabels(context: probot.Context, payload_type: string): Promise<void> {
+  async function runBotForLabels(
+    context: probot.Context,
+    payloadType: string
+  ): Promise<void> {
     const subscriptions = await loadSubscriptions(context);
-    console.log("payload_type=", payload_type);
-    const labels = context.payload[payload_type]['labels'].map(e => e['name']);
+    context.log('payload_type=', payloadType);
+    const labels = context.payload[payloadType]['labels'].map(e => e['name']);
     context.log({labels});
     const cc = new Set();
     // eslint-disable-next-line github/array-foreach
@@ -70,7 +73,7 @@ function myBot(app: probot.Application): void {
     });
     context.log({cc: Array.from(cc)}, 'from subscriptions');
     if (cc.size) {
-      const body = context.payload[payload_type]['body'];
+      const body = context.payload[payloadType]['body'];
       const reCC = /cc( +@[a-zA-Z0-9-/]+)+/;
       const oldCCMatch = body.match(reCC);
       const prevCC = new Set();
@@ -96,11 +99,10 @@ function myBot(app: probot.Application): void {
           ? body.replace(reCC, newCCString)
           : `${body}\n\n${newCCString}`;
         context.log({newBody});
-        if (payload_type == 'issue') {
-            await context.github.issues.update(context.issue({body: newBody}));
-        }
-        else if (payload_type == 'pull_request') {
-            await context.github.pulls.update(context.issue({body: newBody}));
+        if (payloadType === 'issue') {
+          await context.github.issues.update(context.issue({body: newBody}));
+        } else if (payloadType === 'pull_request') {
+          await context.github.pulls.update(context.issue({body: newBody}));
         }
       } else {
         context.log('no action: no change from existing cc list on issue');

--- a/test/auto-cc-bot.test.ts
+++ b/test/auto-cc-bot.test.ts
@@ -49,25 +49,25 @@ Some header text
       .post('/app/installations/2/access_tokens')
       .reply(200, {token: 'test'});
 
-    nockTracker(`
+    nockTracker(
+      `
 Some header text
 
 * ci/windows @ezyang
-`, 'seemethere/test-repo');
+`,
+      'seemethere/test-repo'
+    );
 
     const payload = require('./fixtures/pull_request.labeled');
     payload['pull_request']['body'] = 'Arf arf';
 
     const scope = nock('https://api.github.com')
-      .patch(
-        '/repos/seemethere/test-repo/pulls/20',
-        (body: any) => {
-          expect(body).toMatchObject({
-            body: 'Arf arf\n\ncc @ezyang'
-          });
-          return true;
-        }
-      )
+      .patch('/repos/seemethere/test-repo/pulls/20', (body: any) => {
+        expect(body).toMatchObject({
+          body: 'Arf arf\n\ncc @ezyang'
+        });
+        return true;
+      })
       .reply(200);
 
     await probot.receive({name: 'pull_request', payload, id: '2'});

--- a/test/auto-cc-bot.test.ts
+++ b/test/auto-cc-bot.test.ts
@@ -44,6 +44,37 @@ Some header text
     scope.done();
   });
 
+  test('add a cc when PR is labeled', async () => {
+    nock('https://api.github.com')
+      .post('/app/installations/2/access_tokens')
+      .reply(200, {token: 'test'});
+
+    nockTracker(`
+Some header text
+
+* ci/windows @ezyang
+`, 'seemethere/test-repo');
+
+    const payload = require('./fixtures/pull_request.labeled');
+    payload['pull_request']['body'] = 'Arf arf';
+
+    const scope = nock('https://api.github.com')
+      .patch(
+        '/repos/seemethere/test-repo/pulls/20',
+        (body: any) => {
+          expect(body).toMatchObject({
+            body: 'Arf arf\n\ncc @ezyang'
+          });
+          return true;
+        }
+      )
+      .reply(200);
+
+    await probot.receive({name: 'pull_request', payload, id: '2'});
+
+    scope.done();
+  });
+
   test('update an existing cc when issue is labeled', async () => {
     nock('https://api.github.com')
       .post('/app/installations/2/access_tokens')

--- a/test/ciflow-bot.test.ts
+++ b/test/ciflow-bot.test.ts
@@ -428,7 +428,8 @@ describe('Ruleset Integration Tests', () => {
         {
           id: comment_id,
           node_id: comment_node_id,
-          body: '<!-- ciflow-comment-start -->\nshould_be_removed\n<!-- ciflow-comment-end -->\nshould_not_be_removed \n'
+          body:
+            '<!-- ciflow-comment-start -->\nshould_be_removed\n<!-- ciflow-comment-end -->\nshould_not_be_removed \n'
         }
       ])
       .patch(`/repos/${owner}/${repo}/issues/comments/${comment_id}`, body => {

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,6 +1,9 @@
 import nock from 'nock';
 
-export function nockTracker(contents: string, gha_path: string = "ezyang/testing-ideal-computing-machine"): void {
+export function nockTracker(
+  contents: string,
+  ghaPath: string = 'ezyang/testing-ideal-computing-machine'
+): void {
   // Setup mock for the "tracking issue" which specifies where
   // CC bot can get labels
   const configPayload = require('./fixtures/config.json');
@@ -10,14 +13,12 @@ tracking_issue: 6
 `
   ).toString('base64');
   nock('https://api.github.com')
-    .get(
-      '/repos/' + gha_path + '/contents/.github/pytorch-probot.yml'
-    )
+    .get('/repos/' + ghaPath + '/contents/.github/pytorch-probot.yml')
     .reply(200, configPayload);
 
   const payload = require('./fixtures/issue.json');
   payload['body'] = contents;
   nock('https://api.github.com')
-    .get('/repos/' + gha_path + '/issues/6')
+    .get('/repos/' + ghaPath + '/issues/6')
     .reply(200, payload);
 }

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-export function nockTracker(contents: string): void {
+export function nockTracker(contents: string, gha_path: string = "ezyang/testing-ideal-computing-machine"): void {
   // Setup mock for the "tracking issue" which specifies where
   // CC bot can get labels
   const configPayload = require('./fixtures/config.json');
@@ -11,13 +11,13 @@ tracking_issue: 6
   ).toString('base64');
   nock('https://api.github.com')
     .get(
-      '/repos/ezyang/testing-ideal-computing-machine/contents/.github/pytorch-probot.yml'
+      '/repos/' + gha_path + '/contents/.github/pytorch-probot.yml'
     )
     .reply(200, configPayload);
 
   const payload = require('./fixtures/issue.json');
   payload['body'] = contents;
   nock('https://api.github.com')
-    .get('/repos/ezyang/testing-ideal-computing-machine/issues/6')
+    .get('/repos/' + gha_path + '/issues/6')
     .reply(200, payload);
 }

--- a/test/subscriptions.test.ts
+++ b/test/subscriptions.test.ts
@@ -51,7 +51,7 @@ As a courtesy to others, please do not edit the subscriptions of users who are n
     ).toStrictEqual({
       critical: ['ezyang'],
       'high priority': ['ezyang'],
-      'module: autograd': ['ezyang'],
+      'module: autograd': ['ezyang']
     });
   });
 });


### PR DESCRIPTION
Modify cc-bot to register a listener on "pull_request.labelled" that
reuses the same body-labelling logic

Add a test for that