### PR TITLE
Add transpiled traceback translation for handler.ts

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,3 +1,8 @@
 import {serverless} from '@probot/serverless-lambda';
+import {install} from 'source-map-support';
 import appFn from './';
+
+// Needed for traceback translation from transpiled javascript -> typescript
+install();
+
 module.exports.probot = serverless(appFn);


### PR DESCRIPTION

<img width="995" alt="Screen Shot 2021-09-01 at 12 21 09 PM" src="https://user-images.githubusercontent.com/1700823/131731169-593d0ad7-a32f-483a-97bd-beb7a70fe368.png">
Did not realize that on lambda the actual entrypoint was `dist/handler.probot`