### PR TITLE
Add CIFlow tracking issue parsing logic

### DIFF
--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -5,12 +5,12 @@ import {CachedIssueTracker} from './utils';
 const ciflowCommentStart = '<!-- ciflow-comment-start -->';
 const ciflowCommentEnd = '<!-- ciflow-comment-end -->';
 
-function parseIssue(rawText: string): object {
-  const rows = rawText.split('\r\n');
+export function parseCIFlowIssue(rawText: string): object {
+  const rows = rawText.replace('\r','').split('\n');
   const retval = {};
   // eslint-disable-next-line github/array-foreach
   rows.forEach((row: string) => {
-    const elements = row.split(' ');
+    const elements = row.trim().split(' ');
     if (
       elements.length < 1 ||
       elements[0].length < 1 ||
@@ -348,7 +348,7 @@ export class CIFlowBot {
     const tracker = new CachedIssueTracker(
       app,
       'ciflow_tracking_issue',
-      parseIssue
+      parseCIFlowIssue
     );
     const webhookHandler = async (ctx: probot.Context): Promise<void> => {
       await new CIFlowBot(ctx, tracker).handler();

--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -291,12 +291,6 @@ export class CIFlowBot {
       ?.map(label => label.name);
     this.owner = this.ctx.payload?.repository?.owner?.login;
     this.repo = this.ctx.payload?.repository?.name;
-    if (this.tracker) {
-      const issue = await this.tracker.loadIssue(this.ctx);
-      if (Object.getOwnPropertyNames(issue).length === 0) {
-        return false;
-      }
-    }
 
     if (this.event === CIFlowBot.event_issue_comment) {
       this.comment_author = this.ctx.payload?.comment?.user?.login;

--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -6,7 +6,7 @@ const ciflowCommentStart = '<!-- ciflow-comment-start -->';
 const ciflowCommentEnd = '<!-- ciflow-comment-end -->';
 
 export function parseCIFlowIssue(rawText: string): object {
-  const rows = rawText.replace('\r','').split('\n');
+  const rows = rawText.replace('\r', '').split('\n');
   const retval = {};
   // eslint-disable-next-line github/array-foreach
   rows.forEach((row: string) => {
@@ -46,7 +46,7 @@ export class CIFlowBot {
   static readonly pr_label_prefix = 'ciflow/';
 
   static readonly strategy_add_default_labels = 'strategy_add_default_labels';
-  static readonly defaultLabels = [ 'ciflow/default'];
+  static readonly defaultLabels = ['ciflow/default'];
 
   // Stateful instance variables
   command = '';
@@ -109,8 +109,9 @@ export class CIFlowBot {
     return res?.data?.permission;
   }
 
-  async getUserLabels(): Promise<Array<string>> {
-    const rolloutUsers = this.tracker != null ? await this.tracker.loadIssue(this.ctx) : {};
+  async getUserLabels(): Promise<string[]> {
+    const rolloutUsers =
+      this.tracker != null ? await this.tracker.loadIssue(this.ctx) : {};
     if (this.pr_author in rolloutUsers) {
       return rolloutUsers[this.pr_author];
     }
@@ -338,7 +339,7 @@ export class CIFlowBot {
       'ciflow dispatch started!'
     );
 
-    if (!isValid || this.default_labels.length == 0) {
+    if (!isValid || this.default_labels.length === 0) {
       return;
     }
     await this.dispatch();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,7 @@ export class CachedIssueTracker extends CachedConfigTracker {
         );
         this.repoIssues[key] = this.issueParser('');
       }
-      context.log({issues: this.repoIssues[key]});
+      context.log({parsedIssue: this.repoIssues[key]});
     }
     return this.repoIssues[key];
   }

--- a/test/ciflow-bot.test.ts
+++ b/test/ciflow-bot.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock';
 import * as probot from 'probot';
 import * as utils from './utils';
 import {CIFlowBot, Ruleset} from '../src/ciflow-bot';
+import {nockTracker} from './common';
 
 nock.disableNetConnect();
 jest.setTimeout(60000); // 60 seconds
@@ -152,7 +153,9 @@ describe('CIFlowBot Integration Tests', () => {
       .post('/app/installations/2/access_tokens')
       .reply(200, {token: 'test'});
 
-    jest.spyOn(CIFlowBot.prototype, 'rollout').mockReturnValue(true);
+    nockTracker('@malfet', 'pytorch/pytorch', 'ciflow_tracking_issue: 6');
+
+    jest.spyOn(CIFlowBot.prototype, 'rollout').mockResolvedValue(true);
     jest.spyOn(Ruleset.prototype, 'upsertRootComment').mockReturnValue(null);
   });
 
@@ -192,7 +195,7 @@ describe('CIFlowBot Integration Tests', () => {
   });
 
   test('pull_request.opened event: add_default_labels strategy not rolled out', async () => {
-    jest.spyOn(CIFlowBot.prototype, 'rollout').mockReturnValue(false);
+    jest.spyOn(CIFlowBot.prototype, 'rollout').mockResolvedValue(false);
 
     const event = require('./fixtures/pull_request.opened.json');
     event.payload.pull_request.number = pr_number;
@@ -359,6 +362,7 @@ describe('Ruleset Integration Tests', () => {
     nock('https://api.github.com')
       .post('/app/installations/2/access_tokens')
       .reply(200, {token: 'test'});
+    nockTracker('@octocat ciflow/none', 'pytorch/pytorch');
   });
 
   afterEach(() => {

--- a/test/ciflow-bot.test.ts
+++ b/test/ciflow-bot.test.ts
@@ -123,7 +123,7 @@ describe('CIFlowBot Unit Tests', () => {
     const isValid = await ciflow.setContext();
     expect(isValid).toBe(false);
   });
-
+  /*
   test('parseContext for issue_comment.created invalid owner/repo', async () => {
     const event = require('./fixtures/issue_comment.json');
     event.payload.issue.number = pr_number;
@@ -136,6 +136,7 @@ describe('CIFlowBot Unit Tests', () => {
     const isValid = await ciflow.setContext();
     expect(isValid).toBe(false);
   });
+ */
 });
 
 describe('CIFlowBot Integration Tests', () => {
@@ -153,7 +154,10 @@ describe('CIFlowBot Integration Tests', () => {
       .post('/app/installations/2/access_tokens')
       .reply(200, {token: 'test'});
 
-    nockTracker('@zzj-bot', 'pytorch/pytorch', 'ciflow_tracking_issue: 6');
+    nockTracker(`
+                @zzj-bot
+                @octocat ciflow/default cats`,
+                'pytorch/pytorch', 'ciflow_tracking_issue: 6');
 
     jest.spyOn(Ruleset.prototype, 'upsertRootComment').mockReturnValue(null);
   });
@@ -194,9 +198,9 @@ describe('CIFlowBot Integration Tests', () => {
   });
 
   test('pull_request.opened event: add_default_labels strategy not rolled out', async () => {
-    jest.spyOn(CIFlowBot.prototype, 'getUserLabels').mockResolvedValue([]);
 
     const event = require('./fixtures/pull_request.opened.json');
+    event.payload.pull_request.user.login = 'rumpelstiltskin';
     event.payload.pull_request.number = pr_number;
     event.payload.repository.owner.login = owner;
     event.payload.repository.name = repo;

--- a/test/ciflow-bot.test.ts
+++ b/test/ciflow-bot.test.ts
@@ -153,9 +153,8 @@ describe('CIFlowBot Integration Tests', () => {
       .post('/app/installations/2/access_tokens')
       .reply(200, {token: 'test'});
 
-    nockTracker('@malfet', 'pytorch/pytorch', 'ciflow_tracking_issue: 6');
+    nockTracker('@zzj-bot', 'pytorch/pytorch', 'ciflow_tracking_issue: 6');
 
-    jest.spyOn(CIFlowBot.prototype, 'rollout').mockResolvedValue(true);
     jest.spyOn(Ruleset.prototype, 'upsertRootComment').mockReturnValue(null);
   });
 
@@ -195,7 +194,7 @@ describe('CIFlowBot Integration Tests', () => {
   });
 
   test('pull_request.opened event: add_default_labels strategy not rolled out', async () => {
-    jest.spyOn(CIFlowBot.prototype, 'rollout').mockResolvedValue(false);
+    jest.spyOn(CIFlowBot.prototype, 'getUserLabels').mockResolvedValue([]);
 
     const event = require('./fixtures/pull_request.opened.json');
     event.payload.pull_request.number = pr_number;

--- a/test/ciflow-parse.test.ts
+++ b/test/ciflow-parse.test.ts
@@ -1,0 +1,23 @@
+import {parseCIFlowIssue} from '../src/ciflow-bot';
+
+describe('Parse CIFflow issue', () => {
+  test('Empty', () => {
+    expect(parseCIFlowIssue('')).toStrictEqual({});
+  });
+  test('One line', () => {
+    expect(parseCIFlowIssue('@malfet')).toStrictEqual({'malfet':['ciflow/default']});
+  });
+  test('Empty lines', () => {
+    expect(parseCIFlowIssue(`
+
+                            @malfet
+
+                            `)).toStrictEqual({'malfet':['ciflow/default']});
+  });
+  test('Two users', () => {
+    expect(parseCIFlowIssue(`
+                            @malfet
+                            @octocat cats
+                            `)).toStrictEqual({'malfet':['ciflow/default'], 'octocat': ['cats']});
+  });
+});

--- a/test/common.ts
+++ b/test/common.ts
@@ -2,16 +2,13 @@ import nock from 'nock';
 
 export function nockTracker(
   contents: string,
-  ghaPath: string = 'ezyang/testing-ideal-computing-machine'
+  ghaPath: string = 'ezyang/testing-ideal-computing-machine',
+  configContent: string = 'tracking_issue: 6',
 ): void {
   // Setup mock for the "tracking issue" which specifies where
   // CC bot can get labels
   const configPayload = require('./fixtures/config.json');
-  configPayload['content'] = Buffer.from(
-    `
-tracking_issue: 6
-`
-  ).toString('base64');
+  configPayload['content'] = Buffer.from(configContent).toString('base64');
   nock('https://api.github.com')
     .get('/repos/' + ghaPath + '/contents/.github/pytorch-probot.yml')
     .reply(200, configPayload);


### PR DESCRIPTION
Use `CachedIssueTracker` primitive to read and parse tracked issue
Use `nockTracker` to simulate fake tracking issue
Replace `jest.spyOn(...).mockResolvedValue()` with actual parsing of configs

TODO:
  - Move untracked project test to integration tests

Fixes https://github.com/pytorch/pytorch-probot/issues/56