### PR TITLE
Add bot to add confirmation comments for issues that disable tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {install} from 'source-map-support';
 import autoCcBot from './auto-cc-bot';
 import autoLabelBot from './auto-label-bot';
 import triggerCircleCiBot from './trigger-circleci-workflows';
+import verifyDisableTestIssueBot from './verify-disable-test-issue';
 import {CIFlowBot} from './ciflow-bot';
 import {Application} from 'probot';
 
@@ -13,6 +14,7 @@ function runBot(app: Application): void {
   autoCcBot(app);
   autoLabelBot(app);
   triggerCircleCiBot(app);
+  verifyDisableTestIssueBot(app);
 
   // kill switch for ciflow
   if (process.env.ENABLE_CIFLOWBOT === 'true') {

--- a/src/verify-disable-test-issue.ts
+++ b/src/verify-disable-test-issue.ts
@@ -91,8 +91,8 @@ export function formValidationComment(
     '<body>Hello there! From the DISABLED prefix in this issue title, ';
   body += 'it looks like you are attempting to disable a test in PyTorch CI. ';
   body += 'The information I have parsed is below:\n\n';
-  body += `\* Test name: \`${testName}\`\n`;
-  body += `\* Platforms for which to skip the test: ${platformMsg}\n\n`;
+  body += `* Test name: \`${testName}\`\n`;
+  body += `* Platforms for which to skip the test: ${platformMsg}\n\n`;
 
   if (invalidPlatforms.length > 0) {
     body +=
@@ -113,7 +113,7 @@ export function formValidationComment(
       'information and determine which test to disable. Please modify the ';
     body +=
       'title to be of the format: DISABLED test_case_name (test.ClassName), ';
-    body += 'for example, \`test_cuda_assert_async (\_\_main\_\_.TestCuda)\`.\n\n';
+    body += 'for example, `test_cuda_assert_async (__main__.TestCuda)`.\n\n';
   } else {
     body += `Within ~15 minutes, ${testName} will be disabled in PyTorch CI for `;
     body +=
@@ -121,7 +121,7 @@ export function formValidationComment(
         ? 'all platforms'
         : `these platforms: ${platformsToSkip.join(', ')}`;
     body +=
-      '. Please verify that your test name looks correct, e.g., \`test_cuda_assert_async (\_\_main\_\_.TestCuda)\`.\n\n';
+      '. Please verify that your test name looks correct, e.g., `test_cuda_assert_async (__main__.TestCuda)`.\n\n';
   }
 
   body +=
@@ -129,7 +129,7 @@ export function formValidationComment(
   body +=
     'action will disable the test for all platforms if no platforms list is specified. \n';
   body +=
-    '\`\`\`\nPlatforms: case-insensitive, list, of, platforms\n\`\`\`\nWe currently support the following platforms: ';
+    '```\nPlatforms: case-insensitive, list, of, platforms\n```\nWe currently support the following platforms: ';
   body += `${Array.from(supportedPlatforms)
     .sort((a, b) => a.localeCompare(b))
     .join(', ')}.</body>`;

--- a/src/verify-disable-test-issue.ts
+++ b/src/verify-disable-test-issue.ts
@@ -88,32 +88,32 @@ export function formValidationComment(
   );
 
   let body =
-    '<details>Hello there! From the DISABLED prefix in this issue title, ';
+    '<body>Hello there! From the DISABLED prefix in this issue title, ';
   body += 'it looks like you are attempting to disable a test in PyTorch CI. ';
-  body += 'The information I have parsed is below:\n';
-  body += `<b>Test name<b>: ${testName}\n`;
-  body += `<b>Platforms for which to skip the test<b>: ${platformMsg}\n\n`;
+  body += 'The information I have parsed is below:\n\n';
+  body += `\* Test name: \`${testName}\`\n`;
+  body += `\* Platforms for which to skip the test: ${platformMsg}\n\n`;
 
   if (invalidPlatforms.length > 0) {
     body +=
-      '<b>WARNING!<b> In the parsing process, I received these invalid inputs as platforms for ';
+      '<b>WARNING!</b> In the parsing process, I received these invalid inputs as platforms for ';
     body += `which the test will be disabled: ${invalidPlatforms.join(
       ', '
     )}. These could `;
     body +=
       'be typos or platforms we do not yet support test disabling. Please ';
     body +=
-      'verify the platform list above and modify your issue body if needed.\n';
+      'verify the platform list above and modify your issue body if needed.\n\n';
   }
 
   if (!testNameIsExpected(testName)) {
     body +=
-      '<b>ERROR!<b> As you can see above, I could not properly parse the test ';
+      '<b>ERROR!</b> As you can see above, I could not properly parse the test ';
     body +=
       'information and determine which test to disable. Please modify the ';
     body +=
       'title to be of the format: DISABLED test_case_name (test.ClassName), ';
-    body += 'for example, test_cuda_assert_async (__main__.TestCuda).\n';
+    body += 'for example, \`test_cuda_assert_async (\_\_main\_\_.TestCuda)\`.\n\n';
   } else {
     body += `Within ~15 minutes, ${testName} will be disabled in PyTorch CI for `;
     body +=
@@ -121,18 +121,18 @@ export function formValidationComment(
         ? 'all platforms'
         : `these platforms: ${platformsToSkip.join(', ')}`;
     body +=
-      '. Please verify that your test name looks correct, e.g., test_cuda_assert_async (__main__.TestCuda).\n';
+      '. Please verify that your test name looks correct, e.g., \`test_cuda_assert_async (\_\_main\_\_.TestCuda)\`.\n\n';
   }
 
   body +=
     'To modify the platforms list, please include a line in the issue body, like below. The default ';
   body +=
-    'action will disable the test for all platforms if no platforms list is specified. \n\n';
+    'action will disable the test for all platforms if no platforms list is specified. \n';
   body +=
-    'Platforms: case-insensitive, list, of, platforms\n\nWe currently support the following platforms: ';
+    '\`\`\`\nPlatforms: case-insensitive, list, of, platforms\n\`\`\`\nWe currently support the following platforms: ';
   body += `${Array.from(supportedPlatforms)
     .sort((a, b) => a.localeCompare(b))
-    .join(', ')}.</details>`;
+    .join(', ')}.</body>`;
 
   return validationCommentStart + body + validationCommentEnd;
 }

--- a/src/verify-disable-test-issue.ts
+++ b/src/verify-disable-test-issue.ts
@@ -2,14 +2,27 @@ import * as probot from 'probot';
 
 const validationCommentStart = '<!-- validation-comment-start -->';
 const validationCommentEnd = '<!-- validation-comment-end -->';
-const disabled_key = 'DISABLED'
-const supported_platforms = new Set(['mac', 'macos', 'win', 'windows', 'linux', 'rocm'])
+const disabledKey = 'DISABLED ';
+const supportedPlatforms = new Set([
+  'asan',
+  'linux',
+  'mac',
+  'macos',
+  'rocm',
+  'win',
+  'windows'
+]);
 
-async function getValidationComment(context: any, issue_number: string, owner: string, repo: string) {
+async function getValidationComment(
+  context,
+  issueNumber: string,
+  owner: string,
+  repo: string
+): Promise<[number, string]> {
   const commentsRes = await context.github.issues.listComments({
-    owner: owner,
-    repo: repo,
-    issue_number: issue_number,
+    owner,
+    repo,
+    issueNumber,
     per_page: 10
   });
   for (const comment of commentsRes.data) {
@@ -20,121 +33,159 @@ async function getValidationComment(context: any, issue_number: string, owner: s
   return [0, ''];
 }
 
-function parseTitle(title: string) {
-  const test_name = title.slice(disabled_key.length)
-  const split = test_name.split(/\s+/)
-  const test_case = split[0]
-  let test_suite = ''
-  if (split.length > 1 && split[1].startsWith('(__main__.') && split[1].endsWith(')')) {
-    test_suite = split[1].slice('(__main__.'.length, split[1].length - 1)
-  }
-  return [test_case, test_suite]
-}
-
-function parseBody(body: string) {
-  const lines = body.split(/[\r\n]+/)
-  let platforms_to_skip = new Set();
-  let invalid_platforms = new Set();
-  const key = 'platforms:'
+export function parseBody(body: string): [Set<string>, Set<string>] {
+  const lines = body.split(/[\r\n]+/);
+  const platformsToSkip = new Set<string>();
+  const invalidPlatforms = new Set<string>();
+  const key = 'platforms:';
   for (let line of lines) {
-    line = line.toLowerCase()
+    line = line.toLowerCase();
     if (line.startsWith(key)) {
-      for (let platform of line.slice(key.length).split(/^\s+|\s*,\s*|\s+$/)) {
-        if (supported_platforms.has(platform)) {
-          platforms_to_skip.add(platform)
-        } else {
-          invalid_platforms.add(platform)
+      for (const platform of line
+        .slice(key.length)
+        .split(/^\s+|\s*,\s*|\s+$/)) {
+        if (supportedPlatforms.has(platform)) {
+          platformsToSkip.add(platform);
+        } else if (platform !== '') {
+          invalidPlatforms.add(platform);
         }
       }
     }
   }
-  return [platforms_to_skip, invalid_platforms]
+  return [platformsToSkip, invalidPlatforms];
 }
 
-function formValidationComment(test_info, platforms) {
-  const test_case_name = test_info[0]
-  const test_suite_name = test_info[1]
-  const platforms_to_skip = Array.from(platforms[0]).sort()
-  const platform_msg =
-    platforms_to_skip.length === 0 ? 'none parsed, defaulting to ALL platforms' : platforms_to_skip.join(', ')
-  const invalid_platforms = Array.from(platforms[1]).sort()
+export function parseTitle(title: string): string {
+  return title.slice(disabledKey.length).trim();
+}
 
-  let body = '<details>Hello there! From the DISABLED prefix in this issue title, '
-  body += 'it looks like you are attempting to disable a test in PyTorch CI. '
-  body += 'The information I have parsed is below:\n'
-  body += '<b>Test case name<b>: ' + test_case_name + '\n'
-  body += '<b>Test suite name<b>: ' + test_suite_name + '\n'
-  body += '<b>Platforms for which to skip the test<b>: ' + platform_msg + '\n\n'
-
-  if (!test_case_name || !test_suite_name) {
-    body += '<b>ERROR!<b> As you can see above, I could not properly parse the test '
-    body += 'information and determine which test to disable. Please modify the '
-    body += 'title to be of the format: DISABLED test_case_name (__main__.TestSuiteName).\n'
+function testNameIsExpected(testName: string): boolean {
+  const split = testName.split(' ');
+  if (split.length !== 2) {
+    return false;
   }
 
-  if (invalid_platforms.length > 0) {
-    body += '<b>WARNING!<b> In the parsing process, I received these invalid inputs as platforms for '
-    body += 'which the test will be disabled: ' + invalid_platforms.join(', ') + '. These could '
-    body += 'be typos or platforms we do not yet support test disabling. Please '
-    body += 'verify the platform list above and modify your issue body if needed.\n'
+  const testSuite = split[1].split('.');
+  if (testSuite.length !== 2) {
+    return false;
+  }
+  return true;
+}
+
+export function formValidationComment(
+  testName: string,
+  platforms: [Set<string>, Set<string>]
+): string {
+  const platformsToSkip = Array.from(platforms[0]).sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const platformMsg =
+    platformsToSkip.length === 0
+      ? 'none parsed, defaulting to ALL platforms'
+      : platformsToSkip.join(', ');
+  const invalidPlatforms = Array.from(platforms[1]).sort((a, b) =>
+    a.localeCompare(b)
+  );
+
+  let body =
+    '<details>Hello there! From the DISABLED prefix in this issue title, ';
+  body += 'it looks like you are attempting to disable a test in PyTorch CI. ';
+  body += 'The information I have parsed is below:\n';
+  body += `<b>Test name<b>: ${testName}\n`;
+  body += `<b>Platforms for which to skip the test<b>: ${platformMsg}\n\n`;
+
+  if (invalidPlatforms.length > 0) {
+    body +=
+      '<b>WARNING!<b> In the parsing process, I received these invalid inputs as platforms for ';
+    body += `which the test will be disabled: ${invalidPlatforms.join(
+      ', '
+    )}. These could `;
+    body +=
+      'be typos or platforms we do not yet support test disabling. Please ';
+    body +=
+      'verify the platform list above and modify your issue body if needed.\n';
   }
 
-  if (test_case_name && test_suite_name) {
-    body += 'Within ~15 minutes, test case ' + test_case_name + ' from test suite'
-    body += test_suite_name + 'will be disabled in PyTorch CI for '
-    body += (platforms_to_skip.length === 0 ? 'all platforms' : 'these platforms: ' + platforms_to_skip.join(', '))
-    body += '.\n'
+  if (!testNameIsExpected(testName)) {
+    body +=
+      '<b>ERROR!<b> As you can see above, I could not properly parse the test ';
+    body +=
+      'information and determine which test to disable. Please modify the ';
+    body +=
+      'title to be of the format: DISABLED test_case_name (test.ClassName), ';
+    body += 'for example, test_cuda_assert_async (__main__.TestCuda).\n';
+  } else {
+    body += `Within ~15 minutes, ${testName} will be disabled in PyTorch CI for `;
+    body +=
+      platformsToSkip.length === 0
+        ? 'all platforms'
+        : `these platforms: ${platformsToSkip.join(', ')}`;
+    body +=
+      '. Please verify that your test name looks correct, e.g., test_cuda_assert_async (__main__.TestCuda).\n';
   }
 
-  body += 'To modify the platforms list, please include a line in the issue body:\n\n'
-  body += 'Platforms: case-insensitive, list, of, platforms\n\nWe currently support the following platforms: '
-  body += Array.from(supported_platforms).sort().join(', ') + '.</details>'
+  body +=
+    'To modify the platforms list, please include a line in the issue body, like below. The default ';
+  body +=
+    'action will disable the test for all platforms if no platforms list is specified. \n\n';
+  body +=
+    'Platforms: case-insensitive, list, of, platforms\n\nWe currently support the following platforms: ';
+  body += `${Array.from(supportedPlatforms)
+    .sort((a, b) => a.localeCompare(b))
+    .join(', ')}.</details>`;
 
-  return validationCommentStart + body + validationCommentEnd
+  return validationCommentStart + body + validationCommentEnd;
 }
 
 function myBot(app: probot.Application): void {
-  app.on(['issues.opened', 'issues.edited'], async context => {
-    const state = context.payload['issue']['state']
-    const title = context.payload['issue']['title']
-    const owner = context.github.owner
-    const repo = context.github.repo
+  app.on(
+    ['issues.opened', 'issues.edited'],
+    async (context: probot.Context) => {
+      const state = context.payload['issue']['state'];
+      const title = context.payload['issue']['title'];
+      const owner = context.payload['repository']['owner']['login'];
+      const repo = context.payload['repository']['name'];
 
-    if (state === 'closed' || !title.startsWith(disabled_key)) {
-      return
+      if (state === 'closed' || !title.startsWith(disabledKey)) {
+        return;
+      }
+
+      const body = context.payload['issue']['body'];
+      const number = context.payload['issue']['number'];
+      const existingValidationCommentData = await getValidationComment(
+        context,
+        number,
+        owner,
+        repo
+      );
+      const existingValidationCommentID = existingValidationCommentData[0];
+      const existingValidationComment = existingValidationCommentData[1];
+
+      const testName = parseTitle(title);
+      const platforms = parseBody(body);
+      const validationComment = formValidationComment(testName, platforms);
+
+      if (existingValidationComment === validationComment) {
+        return;
+      }
+
+      if (existingValidationCommentID === 0) {
+        await context.github.issues.createComment({
+          body: validationComment,
+          owner,
+          repo,
+          issue_number: number
+        });
+      } else {
+        await context.github.issues.updateComment({
+          body: validationComment,
+          owner,
+          repo,
+          comment_id: existingValidationCommentID
+        });
+      }
     }
-
-    const body = context.payload['issue']['body']
-    const number = context.payload['issue']['number']
-    const existingValidationCommentData = await getValidationComment(context, number, owner, repo)
-    const existingValidationCommentID = existingValidationCommentData[0]
-    const existingValidationComment = existingValidationCommentData[1]
-
-    const test_info = parseTitle(title)
-    const platforms = parseBody(body)
-    const validationComment = formValidationComment(test_info, platforms)
-
-    if (existingValidationComment === validationComment) {
-      return
-    }
-
-    if (existingValidationCommentID === 0) {
-      const res = await this.ctx.github.issues.createComment({
-        validationComment,
-        owner: owner,
-        repo: repo,
-        issue_number: number
-      });
-      const newCommentID = res.data.id;
-    } else {
-      await this.ctx.github.issues.updateComment({
-        validationComment,
-        owner: owner,
-        repo: repo,
-        comment_id: existingValidationCommentID
-      });
-    }
-  });
+  );
 }
 
 export default myBot;

--- a/src/verify-disable-test-issue.ts
+++ b/src/verify-disable-test-issue.ts
@@ -1,0 +1,140 @@
+import * as probot from 'probot';
+
+const validationCommentStart = '<!-- validation-comment-start -->';
+const validationCommentEnd = '<!-- validation-comment-end -->';
+const disabled_key = 'DISABLED'
+const supported_platforms = new Set(['mac', 'macos', 'win', 'windows', 'linux', 'rocm'])
+
+async function getValidationComment(context: any, issue_number: string, owner: string, repo: string) {
+  const commentsRes = await context.github.issues.listComments({
+    owner: owner,
+    repo: repo,
+    issue_number: issue_number,
+    per_page: 10
+  });
+  for (const comment of commentsRes.data) {
+    if (comment.body.includes(validationCommentStart)) {
+      return [comment.id, comment.body];
+    }
+  }
+  return [0, ''];
+}
+
+function parseTitle(title: string) {
+  const test_name = title.slice(disabled_key.length)
+  const split = test_name.split(/\s+/)
+  const test_case = split[0]
+  let test_suite = ''
+  if (split.length > 1 && split[1].startsWith('(__main__.') && split[1].endsWith(')')) {
+    test_suite = split[1].slice('(__main__.'.length, split[1].length - 1)
+  }
+  return [test_case, test_suite]
+}
+
+function parseBody(body: string) {
+  const lines = body.split(/[\r\n]+/)
+  let platforms_to_skip = new Set();
+  let invalid_platforms = new Set();
+  const key = 'platforms:'
+  for (let line of lines) {
+    line = line.toLowerCase()
+    if (line.startsWith(key)) {
+      for (let platform of line.slice(key.length).split(/^\s+|\s*,\s*|\s+$/)) {
+        if (supported_platforms.has(platform)) {
+          platforms_to_skip.add(platform)
+        } else {
+          invalid_platforms.add(platform)
+        }
+      }
+    }
+  }
+  return [platforms_to_skip, invalid_platforms]
+}
+
+function formValidationComment(test_info, platforms) {
+  const test_case_name = test_info[0]
+  const test_suite_name = test_info[1]
+  const platforms_to_skip = Array.from(platforms[0]).sort()
+  const platform_msg =
+    platforms_to_skip.length === 0 ? 'none parsed, defaulting to ALL platforms' : platforms_to_skip.join(', ')
+  const invalid_platforms = Array.from(platforms[1]).sort()
+
+  let body = '<details>Hello there! From the DISABLED prefix in this issue title, '
+  body += 'it looks like you are attempting to disable a test in PyTorch CI. '
+  body += 'The information I have parsed is below:\n'
+  body += '<b>Test case name<b>: ' + test_case_name + '\n'
+  body += '<b>Test suite name<b>: ' + test_suite_name + '\n'
+  body += '<b>Platforms for which to skip the test<b>: ' + platform_msg + '\n\n'
+
+  if (!test_case_name || !test_suite_name) {
+    body += '<b>ERROR!<b> As you can see above, I could not properly parse the test '
+    body += 'information and determine which test to disable. Please modify the '
+    body += 'title to be of the format: DISABLED test_case_name (__main__.TestSuiteName).\n'
+  }
+
+  if (invalid_platforms.length > 0) {
+    body += '<b>WARNING!<b> In the parsing process, I received these invalid inputs as platforms for '
+    body += 'which the test will be disabled: ' + invalid_platforms.join(', ') + '. These could '
+    body += 'be typos or platforms we do not yet support test disabling. Please '
+    body += 'verify the platform list above and modify your issue body if needed.\n'
+  }
+
+  if (test_case_name && test_suite_name) {
+    body += 'Within ~15 minutes, test case ' + test_case_name + ' from test suite'
+    body += test_suite_name + 'will be disabled in PyTorch CI for '
+    body += (platforms_to_skip.length === 0 ? 'all platforms' : 'these platforms: ' + platforms_to_skip.join(', '))
+    body += '.\n'
+  }
+
+  body += 'To modify the platforms list, please include a line in the issue body:\n\n'
+  body += 'Platforms: case-insensitive, list, of, platforms\n\nWe currently support the following platforms: '
+  body += Array.from(supported_platforms).sort().join(', ') + '.</details>'
+
+  return validationCommentStart + body + validationCommentEnd
+}
+
+function myBot(app: probot.Application): void {
+  app.on(['issues.opened', 'issues.edited'], async context => {
+    const state = context.payload['issue']['state']
+    const title = context.payload['issue']['title']
+    const owner = context.github.owner
+    const repo = context.github.repo
+
+    if (state === 'closed' || !title.startsWith(disabled_key)) {
+      return
+    }
+
+    const body = context.payload['issue']['body']
+    const number = context.payload['issue']['number']
+    const existingValidationCommentData = await getValidationComment(context, number, owner, repo)
+    const existingValidationCommentID = existingValidationCommentData[0]
+    const existingValidationComment = existingValidationCommentData[1]
+
+    const test_info = parseTitle(title)
+    const platforms = parseBody(body)
+    const validationComment = formValidationComment(test_info, platforms)
+
+    if (existingValidationComment === validationComment) {
+      return
+    }
+
+    if (existingValidationCommentID === 0) {
+      const res = await this.ctx.github.issues.createComment({
+        validationComment,
+        owner: owner,
+        repo: repo,
+        issue_number: number
+      });
+      const newCommentID = res.data.id;
+    } else {
+      await this.ctx.github.issues.updateComment({
+        validationComment,
+        owner: owner,
+        repo: repo,
+        comment_id: existingValidationCommentID
+      });
+    }
+  });
+}
+
+export default myBot;

--- a/test/verify-disable-test-issue.test.ts
+++ b/test/verify-disable-test-issue.test.ts
@@ -1,0 +1,121 @@
+import nock from 'nock';
+import {Probot} from 'probot';
+import * as utils from './utils';
+import myProbotApp from '../src/verify-disable-test-issue';
+import * as botUtils from '../src/verify-disable-test-issue';
+
+nock.disableNetConnect();
+
+describe('verify-disable-test-issue', () => {
+  let probot: Probot;
+
+  beforeEach(() => {
+    probot = utils.testProbot();
+    probot.load(myProbotApp);
+  });
+
+  test('issue opened with title starts w/ DISABLED: disable for win', async () => {
+    const title = 'DISABLED testMethodName (testClass.TestSuite)';
+    const body = 'whatever\nPlatforms:win\nyay'
+
+    const platforms = botUtils.parseBody(body);
+    const testName = botUtils.parseTitle(title);
+    expect(platforms).toMatchObject([new Set(['win']), new Set()]);
+    expect(testName).toEqual('testMethodName (testClass.TestSuite)');
+
+    const comment = botUtils.formValidationComment(testName, platforms);
+    expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
+    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
+    expect(comment.includes('these platforms: win.')).toBeTruthy();
+    expect(comment.includes('ERROR')).toBeFalsy();
+    expect(comment.includes('WARNING')).toBeFalsy();
+  });
+
+  test('issue opened with title starts w/ DISABLED: disable for windows, rocm, asan', async () => {
+    const title = 'DISABLED testMethodName (testClass.TestSuite)';
+    const body = 'whatever\nPlatforms:windows, ROCm, ASAN\nyay'
+
+    const platforms = botUtils.parseBody(body);
+    const testName = botUtils.parseTitle(title);
+    expect(platforms).toMatchObject([new Set(['windows', 'rocm', 'asan']), new Set()]);
+    expect(testName).toEqual('testMethodName (testClass.TestSuite)');
+
+    const comment = botUtils.formValidationComment(testName, platforms);
+
+    expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
+    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
+    expect(comment.includes('these platforms: asan, rocm, windows.')).toBeTruthy();
+    expect(comment.includes('ERROR')).toBeFalsy();
+    expect(comment.includes('WARNING')).toBeFalsy();
+  });
+
+  test('issue opened with title starts w/ DISABLED: disable for all', async () => {
+    const title = 'DISABLED testMethodName (testClass.TestSuite)';
+    const body = 'whatever yay'
+
+    const platforms = botUtils.parseBody(body);
+    const testName = botUtils.parseTitle(title);
+    expect(platforms).toMatchObject([new Set(), new Set()]);
+    expect(testName).toEqual('testMethodName (testClass.TestSuite)');
+
+    const comment = botUtils.formValidationComment(testName, platforms);
+    expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
+    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
+    expect(comment.includes('all platforms.')).toBeTruthy();
+    expect(comment.includes('ERROR')).toBeFalsy();
+    expect(comment.includes('WARNING')).toBeFalsy();
+  });
+
+  test('issue opened with title starts w/ DISABLED: disable unknown platform', async () => {
+    const title = 'DISABLED testMethodName (testClass.TestSuite)';
+    const body = 'whatever\nPlatforms:everything\nyay'
+
+    const platforms = botUtils.parseBody(body);
+    const testName = botUtils.parseTitle(title);
+    expect(platforms).toMatchObject([new Set(), new Set(['everything'])]);
+    expect(testName).toEqual('testMethodName (testClass.TestSuite)');
+
+    const comment = botUtils.formValidationComment(testName, platforms);
+
+    expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
+    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
+    expect(comment.includes('all platforms.')).toBeTruthy();
+    expect(comment.includes('ERROR')).toBeFalsy();
+    expect(comment.includes('WARNING')).toBeTruthy();
+    expect(comment.includes('invalid inputs as platforms for which the test will be disabled: everything.')).toBeTruthy();
+  });
+
+  test('issue opened with title starts w/ DISABLED: cannot parse test', async () => {
+    const title = 'DISABLED testMethodName   cuz it borked  ';
+    const body = 'whatever\nPlatforms:\nyay'
+
+    const platforms = botUtils.parseBody(body);
+    const testName = botUtils.parseTitle(title);
+    expect(platforms).toMatchObject([new Set(), new Set()]);
+    expect(testName).toEqual('testMethodName   cuz it borked');
+
+    const comment = botUtils.formValidationComment(testName, platforms);
+    expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
+    expect(comment.includes('~15 minutes')).toBeFalsy();
+    expect(comment.includes('ERROR')).toBeTruthy();
+    expect(comment.includes('WARNING')).toBeFalsy();
+  });
+
+  test('issue opened with title starts w/ DISABLED: cannot parse test nor platforms', async () => {
+    const title = 'DISABLED testMethodName   cuz it borked  ';
+    const body = 'whatever\nPlatforms:all of them\nyay'
+
+    const platforms = botUtils.parseBody(body);
+    const testName = botUtils.parseTitle(title);
+    expect(platforms).toMatchObject([new Set(), new Set(['all of them'])]);
+    expect(testName).toEqual('testMethodName   cuz it borked');
+
+    const comment = botUtils.formValidationComment(testName, platforms);
+    console.log(comment)
+
+    expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
+    expect(comment.includes('~15 minutes')).toBeFalsy();
+    expect(comment.includes('ERROR')).toBeTruthy();
+    expect(comment.includes('WARNING')).toBeTruthy();
+  });
+});

--- a/test/verify-disable-test-issue.test.ts
+++ b/test/verify-disable-test-issue.test.ts
@@ -1,7 +1,6 @@
 import {Probot} from 'probot';
 import * as utils from './utils';
-import myProbotApp from '../src/verify-disable-test-issue';
-import * as botUtils from '../src/verify-disable-test-issue';
+import myProbotApp, * as botUtils from '../src/verify-disable-test-issue';
 
 describe('verify-disable-test-issue', () => {
   let probot: Probot;
@@ -13,7 +12,7 @@ describe('verify-disable-test-issue', () => {
 
   test('issue opened with title starts w/ DISABLED: disable for win', async () => {
     const title = 'DISABLED testMethodName (testClass.TestSuite)';
-    const body = 'whatever\nPlatforms:win\nyay'
+    const body = 'whatever\nPlatforms:win\nyay';
 
     const platforms = botUtils.parseBody(body);
     const testName = botUtils.parseTitle(title);
@@ -22,7 +21,11 @@ describe('verify-disable-test-issue', () => {
 
     const comment = botUtils.formValidationComment(testName, platforms);
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
-    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
+    expect(
+      comment.includes(
+        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+      )
+    ).toBeTruthy();
     expect(comment.includes('these platforms: win.')).toBeTruthy();
     expect(comment.includes('ERROR')).toBeFalsy();
     expect(comment.includes('WARNING')).toBeFalsy();
@@ -30,24 +33,33 @@ describe('verify-disable-test-issue', () => {
 
   test('issue opened with title starts w/ DISABLED: disable for windows, rocm, asan', async () => {
     const title = 'DISABLED testMethodName (testClass.TestSuite)';
-    const body = 'whatever\nPlatforms:windows, ROCm, ASAN\nyay'
+    const body = 'whatever\nPlatforms:windows, ROCm, ASAN\nyay';
 
     const platforms = botUtils.parseBody(body);
     const testName = botUtils.parseTitle(title);
-    expect(platforms).toMatchObject([new Set(['windows', 'rocm', 'asan']), new Set()]);
+    expect(platforms).toMatchObject([
+      new Set(['windows', 'rocm', 'asan']),
+      new Set()
+    ]);
     expect(testName).toEqual('testMethodName (testClass.TestSuite)');
 
     const comment = botUtils.formValidationComment(testName, platforms);
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
-    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
-    expect(comment.includes('these platforms: asan, rocm, windows.')).toBeTruthy();
+    expect(
+      comment.includes(
+        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+      )
+    ).toBeTruthy();
+    expect(
+      comment.includes('these platforms: asan, rocm, windows.')
+    ).toBeTruthy();
     expect(comment.includes('ERROR')).toBeFalsy();
     expect(comment.includes('WARNING')).toBeFalsy();
   });
 
   test('issue opened with title starts w/ DISABLED: disable for all', async () => {
     const title = 'DISABLED testMethodName (testClass.TestSuite)';
-    const body = 'whatever yay'
+    const body = 'whatever yay';
 
     const platforms = botUtils.parseBody(body);
     const testName = botUtils.parseTitle(title);
@@ -56,7 +68,11 @@ describe('verify-disable-test-issue', () => {
 
     const comment = botUtils.formValidationComment(testName, platforms);
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
-    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
+    expect(
+      comment.includes(
+        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+      )
+    ).toBeTruthy();
     expect(comment.includes('all platforms.')).toBeTruthy();
     expect(comment.includes('ERROR')).toBeFalsy();
     expect(comment.includes('WARNING')).toBeFalsy();
@@ -64,7 +80,7 @@ describe('verify-disable-test-issue', () => {
 
   test('issue opened with title starts w/ DISABLED: disable unknown platform', async () => {
     const title = 'DISABLED testMethodName (testClass.TestSuite)';
-    const body = 'whatever\nPlatforms:everything\nyay'
+    const body = 'whatever\nPlatforms:everything\nyay';
 
     const platforms = botUtils.parseBody(body);
     const testName = botUtils.parseTitle(title);
@@ -73,16 +89,24 @@ describe('verify-disable-test-issue', () => {
 
     const comment = botUtils.formValidationComment(testName, platforms);
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
-    expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
+    expect(
+      comment.includes(
+        '~15 minutes, testMethodName (testClass.TestSuite) will be disabled'
+      )
+    ).toBeTruthy();
     expect(comment.includes('all platforms.')).toBeTruthy();
     expect(comment.includes('ERROR')).toBeFalsy();
     expect(comment.includes('WARNING')).toBeTruthy();
-    expect(comment.includes('invalid inputs as platforms for which the test will be disabled: everything.')).toBeTruthy();
+    expect(
+      comment.includes(
+        'invalid inputs as platforms for which the test will be disabled: everything.'
+      )
+    ).toBeTruthy();
   });
 
   test('issue opened with title starts w/ DISABLED: cannot parse test', async () => {
     const title = 'DISABLED testMethodName   cuz it borked  ';
-    const body = 'whatever\nPlatforms:\nyay'
+    const body = 'whatever\nPlatforms:\nyay';
 
     const platforms = botUtils.parseBody(body);
     const testName = botUtils.parseTitle(title);
@@ -98,7 +122,7 @@ describe('verify-disable-test-issue', () => {
 
   test('issue opened with title starts w/ DISABLED: cannot parse test nor platforms', async () => {
     const title = 'DISABLED testMethodName   cuz it borked  ';
-    const body = 'whatever\nPlatforms:all of them\nyay'
+    const body = 'whatever\nPlatforms:all of them\nyay';
 
     const platforms = botUtils.parseBody(body);
     const testName = botUtils.parseTitle(title);

--- a/test/verify-disable-test-issue.test.ts
+++ b/test/verify-disable-test-issue.test.ts
@@ -1,10 +1,7 @@
-import nock from 'nock';
 import {Probot} from 'probot';
 import * as utils from './utils';
 import myProbotApp from '../src/verify-disable-test-issue';
 import * as botUtils from '../src/verify-disable-test-issue';
-
-nock.disableNetConnect();
 
 describe('verify-disable-test-issue', () => {
   let probot: Probot;
@@ -41,7 +38,6 @@ describe('verify-disable-test-issue', () => {
     expect(testName).toEqual('testMethodName (testClass.TestSuite)');
 
     const comment = botUtils.formValidationComment(testName, platforms);
-
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
     expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
     expect(comment.includes('these platforms: asan, rocm, windows.')).toBeTruthy();
@@ -76,7 +72,6 @@ describe('verify-disable-test-issue', () => {
     expect(testName).toEqual('testMethodName (testClass.TestSuite)');
 
     const comment = botUtils.formValidationComment(testName, platforms);
-
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
     expect(comment.includes('~15 minutes, testMethodName (testClass.TestSuite) will be disabled')).toBeTruthy();
     expect(comment.includes('all platforms.')).toBeTruthy();
@@ -111,8 +106,6 @@ describe('verify-disable-test-issue', () => {
     expect(testName).toEqual('testMethodName   cuz it borked');
 
     const comment = botUtils.formValidationComment(testName, platforms);
-    console.log(comment)
-
     expect(comment.includes('<!-- validation-comment-start -->')).toBeTruthy();
     expect(comment.includes('~15 minutes')).toBeFalsy();
     expect(comment.includes('ERROR')).toBeTruthy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "./dist",
         "allowJs": true,
-        "target": "es5",
+        "target": "ES2015",
         "esModuleInterop": true
     },
     "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "./dist",
         "allowJs": true,
-        "target": "ES2015",
+        "target": "es5",
         "esModuleInterop": true
     },
     "include": [


### PR DESCRIPTION
The below 2 comments shows what should be commented on issues with DISABLED in their titles. The first is when the issue isn't well formatted and the second is when it is.