### PR TITLE
Do not trigger dispatch for default workflow

### DIFF
--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -162,11 +162,11 @@ export class CIFlowBot {
     }
   }
 
-  // signalGithub sends a signal to GitHub to trigger the dispatch
+  // triggerGHADispatch sends a signal to GitHub to trigger the dispatch
   // The logic here is leverage some event that's rarely triggered by other users or bots,
   // thus we pick "assign/unassign" to begin with. See details from the CIFlow RFC:
   // https://github.com/pytorch/pytorch/issues/61888
-  async signalGithub(): Promise<void> {
+  async triggerGHADispatch(): Promise<void> {
     await this.ctx.github.issues.addAssignees({
       owner: this.owner,
       repo: this.repo,
@@ -180,6 +180,11 @@ export class CIFlowBot {
       issue_number: this.pr_number,
       assignees: [CIFlowBot.bot_assignee]
     });
+  }
+
+  // signalGithub triggers a dispatch (if needed) as well as reacts to the comment
+  async signalGithub(): Promise<void> {
+    await this.triggerGHADispatch();
 
     if (this.event === CIFlowBot.event_issue_comment) {
       await this.ctx.github.reactions.createForIssueComment({

--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -184,7 +184,13 @@ export class CIFlowBot {
 
   // signalGithub triggers a dispatch (if needed) as well as reacts to the comment
   async signalGithub(): Promise<void> {
-    await this.triggerGHADispatch();
+    if (this.event === CIFlowBot.event_pull_request &&
+        this.default_labels.length === CIFlowBot.defaultLabels.length &&
+          this.default_labels.every((val, idx) => val === CIFlowBot.defaultLabels[idx])) {
+      this.ctx.log.info('skipping pull request dispatch for defaultLabel');
+    } else {
+      await this.triggerGHADispatch();
+    }
 
     if (this.event === CIFlowBot.event_issue_comment) {
       await this.ctx.github.reactions.createForIssueComment({

--- a/src/ciflow-bot.ts
+++ b/src/ciflow-bot.ts
@@ -184,9 +184,13 @@ export class CIFlowBot {
 
   // signalGithub triggers a dispatch (if needed) as well as reacts to the comment
   async signalGithub(): Promise<void> {
-    if (this.event === CIFlowBot.event_pull_request &&
-        this.default_labels.length === CIFlowBot.defaultLabels.length &&
-          this.default_labels.every((val, idx) => val === CIFlowBot.defaultLabels[idx])) {
+    if (
+      this.event === CIFlowBot.event_pull_request &&
+      this.default_labels.length === CIFlowBot.defaultLabels.length &&
+      this.default_labels.every(
+        (val, idx) => val === CIFlowBot.defaultLabels[idx]
+      )
+    ) {
       this.ctx.log.info('skipping pull request dispatch for defaultLabel');
     } else {
       await this.triggerGHADispatch();

--- a/test/ciflow-bot.test.ts
+++ b/test/ciflow-bot.test.ts
@@ -177,16 +177,6 @@ describe('CIFlowBot Integration Tests', () => {
         expect(body).toMatchObject(['ciflow/default']);
         return true;
       })
-      .reply(200)
-      .post(`/repos/${owner}/${repo}/issues/${pr_number}/assignees`, body => {
-        expect(body).toMatchObject({assignees: [CIFlowBot.bot_assignee]});
-        return true;
-      })
-      .reply(200)
-      .delete(`/repos/${owner}/${repo}/issues/${pr_number}/assignees`, body => {
-        expect(body).toMatchObject({assignees: [CIFlowBot.bot_assignee]});
-        return true;
-      })
       .reply(200);
 
     await p.receive(event);


### PR DESCRIPTION
Avoids cancelled jobs as well as confusing DrCI comments about failures for unknown reason that look like the following:
![image](https://user-images.githubusercontent.com/2453524/133681486-15806a04-b69a-4ed6-8b11-335382f8a4af.png)


Introduces `triggerGHADispatch()` async function
    
As `signalGithub()` is responsible for doing following 3 things:
   - Triggering dispatch, if done via comment or labels are different than default
   - Upserting comment
   - Reacts to comment requesting re-trigger
